### PR TITLE
Add missing expected L.MSG_AC and L.MSG_AC_FULL

### DIFF
--- a/MikScrollingBattleText/Localization/localization.lua
+++ b/MikScrollingBattleText/Localization/localization.lua
@@ -81,6 +81,8 @@ L.MSG_STATIC			= "Static"
 
 L.MSG_COMBAT					= "Combat"
 L.MSG_DISPEL					= "Dispel"
+L.MSG_AC						= "Arcane Charge"
+L.MSG_AC_FULL					= "Arcane Charge Full"
 L.MSG_CP						= "CP"
 L.MSG_CHI_FULL					= "Full Chi"
 L.MSG_CP_FULL					= "Finish It"


### PR DESCRIPTION
MSBT would error out at MSBTProfiles.lua lines 1041 and 1047 with string concatenation errors when trying to load. Re-Adding L.MSG_AC and L.MSG_AC_FULL fixes the issue